### PR TITLE
major: default service port changed from 9001 to 8080

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.0.0] - 2024-05-14
+### Changed
+- Default port for services changed from 9001 to 8080.
+
 ## [2.13.0] - 2024-03-17
 ### Added
 - Support addition of container group id for concurrent component test runs.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ environment "TESTCONTAINERS_REUSE_ENABLE", System.getProperty('containers.stayup
 | service.name                                    | The name of the service, used in the service Docker container name.                                                                                                                                                                                                                                                                                                             | app                                               |
 | service.instance.count                          | The number of instances of the service under test to start.                                                                                                                                                                                                                                                                                                                     | 1                                                 |
 | service.image.tag                               | The tagged image of the service Docker container to use.                                                                                                                                                                                                                                                                                                                        | latest                                            |
-| service.port                                    | The service port number.                                                                                                                                                                                                                                                                                                                                                        | 9001                                              |
+| service.port                                    | The service port number.                                                                                                                                                                                                                                                                                                                                                        | 8080                                              |
 | service.debug.port                              | The port for remote debugging the service.                                                                                                                                                                                                                                                                                                                                      | 5001                                              |
 | service.debug.suspend                           | Use suspend=y for remote debugging params. Useful for diagnosing service startup issues.                                                                                                                                                                                                                                                                                        | false                                             |
 | service.envvars                                 | A comma-separated list of key=value pairs to pass as environment variables for the service container, e.g. ARG1=value1,ARG2=value2".                                                                                                                                                                                                                                            |                                                   |
@@ -327,7 +327,7 @@ Add the Maven Surefire Plugin to the pom of the service under test with the foll
                         </environmentVariables>
                         <systemPropertyVariables>
                             <service.instance.count>3</service.instance.count>
-                            <service.port>9001</service.port>
+                            <service.port>8080</service.port>
                             <service.debug.port>5001</service.debug.port>
                             <kafka.enabled>true</kafka.enabled>
                             <kafka.broker.count>3</kafka.broker.count>
@@ -433,7 +433,7 @@ For the default Micronaut health endpoint configure this to `/health`.  Ensure t
 
 Alternatively the presence of a startup log message can be used to determine whether the service has successfully started, using the `service.startup.log.message` configuration.  Set this to the regex String to match on.  For example, set this property to `.*Startup completed.*` to match the following log message from a Micronaut application:
 ```
-2024-02-27 14:05:46 INFO  i.m.r.Micronaut - Startup completed in 31ms. Server Running: http://d911af15be07:9001
+2024-02-27 14:05:46 INFO  i.m.r.Micronaut - Startup completed in 31ms. Server Running: http://d911af15be07:8080
 ```
 
 If this property is set it will be used instead of the startup health endpoint property.
@@ -597,7 +597,7 @@ Execute a test run, leaving the containers up, with `containers.stayup`.  Now re
 The mapped debug port can be discovered by listing the Docker containers with `docker ps` and viewing the mapping.
 ```
 CONTAINER ID   IMAGE                           COMMAND                   CREATED          STATUS          PORTS                                                        NAMES
-19b474ec03e8   ct/ctf-example-service:latest   "sh -c 'java ${JAVA_…"    6 seconds ago    Up 5 seconds    0.0.0.0:57583->5001/tcp, 0.0.0.0:57584->9001/tcp             ct-ctf-example-service-1
+19b474ec03e8   ct/ctf-example-service:latest   "sh -c 'java ${JAVA_…"    6 seconds ago    Up 5 seconds    0.0.0.0:57583->5001/tcp, 0.0.0.0:57584->8080/tcp             ct-ctf-example-service-1
 ```
 
 As the configured debug port by default is `5001`, then the mapped port can be seen to be `57583`.

--- a/src/main/java/dev/lydtech/component/framework/configuration/TestcontainersConfiguration.java
+++ b/src/main/java/dev/lydtech/component/framework/configuration/TestcontainersConfiguration.java
@@ -34,7 +34,7 @@ public final class TestcontainersConfiguration {
 
     private static final String DEFAULT_SERVICE_NAME = "app";
     private static final String DEFAULT_SERVICE_INSTANCE_COUNT = "1";
-    private static final String DEFAULT_SERVICE_PORT = "9001";
+    private static final String DEFAULT_SERVICE_PORT = "8080";
     private static final String DEFAULT_SERVICE_DEBUG_PORT = "5001";
     private static final String DEFAULT_SERVICE_STARTUP_TIMEOUT_SECONDS = "180";
     private static final String DEFAULT_SERVICE_CONFIG_FILES_SYSTEM_PROPERTY = "spring.config.additional-location";

--- a/src/test/java/dev/lydtech/component/framework/configuration/TestcontainersConfigurationTest.java
+++ b/src/test/java/dev/lydtech/component/framework/configuration/TestcontainersConfigurationTest.java
@@ -125,7 +125,7 @@ public class TestcontainersConfigurationTest {
         assertThat(CONTAINER_APPEND_GROUP_ID, equalTo(false));
         assertThat(SERVICE_NAME, equalTo("app"));
         assertThat(SERVICE_INSTANCE_COUNT, equalTo(1));
-        assertThat(SERVICE_PORT, equalTo(9001));
+        assertThat(SERVICE_PORT, equalTo(8080));
         assertThat(SERVICE_DEBUG_PORT, equalTo(5001));
         assertThat(SERVICE_STARTUP_TIMEOUT_SECONDS, equalTo(180));
         assertThat(SERVICE_STARTUP_HEALTH_ENDPOINT, equalTo("/actuator/health"));


### PR DESCRIPTION
Changes the default service port from 9001 to 8080.  This aligns with spring and removes the need to configure services with port 9001